### PR TITLE
Tilemap group properties

### DIFF
--- a/src/tilemaps/mapdata/LayerData.js
+++ b/src/tilemaps/mapdata/LayerData.js
@@ -149,10 +149,10 @@ var LayerData = new Class({
          * Layer specific properties (can be specified in Tiled)
          *
          * @name Phaser.Tilemaps.LayerData#properties
-         * @type {object[]}
+         * @type {object}
          * @since 3.0.0
          */
-        this.properties = GetFastValue(config, 'properties', []);
+        this.properties = GetFastValue(config, 'properties', {});
 
         /**
          * Tile ID index map.

--- a/src/tilemaps/parsers/tiled/ConvertProperties.js
+++ b/src/tilemaps/parsers/tiled/ConvertProperties.js
@@ -1,0 +1,20 @@
+/**
+ * @author       Florian Cargoët <florian@floriancargoet.com>
+ * @copyright    2020 Photon Storm Ltd.
+ * @license      {@link https://opensource.org/licenses/MIT|MIT License}
+ */
+
+var ConvertProperties = function (propertyList)
+{
+    var properties = {};
+    if (Array.isArray(propertyList))
+    {
+        propertyList.forEach(function (property)
+        {
+            properties[property['name']] = property['value'];
+        });
+    }
+    return properties;
+};
+
+module.exports = ConvertProperties;

--- a/src/tilemaps/parsers/tiled/CreateGroupLayer.js
+++ b/src/tilemaps/parsers/tiled/CreateGroupLayer.js
@@ -5,6 +5,8 @@
  */
 
 var GetFastValue = require('../../../utils/object/GetFastValue');
+var Extend = require('../../../utils/object/Extend');
+var ConvertProperties = require('./ConvertProperties');
 
 /**
  * Parse a Tiled group layer and create a state object for inheriting.
@@ -32,7 +34,8 @@ var CreateGroupLayer = function (json, groupl, parentstate)
             opacity: 1,
             visible: true,
             x: 0,
-            y: 0
+            y: 0,
+            properties: {}
         };
     }
 
@@ -48,7 +51,8 @@ var CreateGroupLayer = function (json, groupl, parentstate)
         opacity: parentstate.opacity * groupl.opacity,
         visible: parentstate.visible && groupl.visible,
         x: parentstate.x + layerX,
-        y: parentstate.y + layerY
+        y: parentstate.y + layerY,
+        properties: Extend({}, parentstate.properties, ConvertProperties(groupl.properties))
     };
 };
 

--- a/src/tilemaps/parsers/tiled/ParseImageLayers.js
+++ b/src/tilemaps/parsers/tiled/ParseImageLayers.js
@@ -6,6 +6,7 @@
 
 var GetFastValue = require('../../../utils/object/GetFastValue');
 var CreateGroupLayer = require('./CreateGroupLayer');
+var ConvertProperties = require('./ConvertProperties');
 
 /**
  * Parses a Tiled JSON object into an array of objects with details about the image layers.
@@ -72,7 +73,7 @@ var ParseImageLayers = function (json)
             y: (curGroupState.y + layerOffsetY + curi.y),
             alpha: (curGroupState.opacity * curi.opacity),
             visible: (curGroupState.visible && curi.visible),
-            properties: GetFastValue(curi, 'properties', {})
+            properties: ConvertProperties(curi.properties)
         });
     }
 

--- a/src/tilemaps/parsers/tiled/ParseImageLayers.js
+++ b/src/tilemaps/parsers/tiled/ParseImageLayers.js
@@ -4,6 +4,7 @@
  * @license      {@link https://opensource.org/licenses/MIT|MIT License}
  */
 
+var Extend = require('../../../utils/object/Extend');
 var GetFastValue = require('../../../utils/object/GetFastValue');
 var CreateGroupLayer = require('./CreateGroupLayer');
 var ConvertProperties = require('./ConvertProperties');
@@ -73,7 +74,8 @@ var ParseImageLayers = function (json)
             y: (curGroupState.y + layerOffsetY + curi.y),
             alpha: (curGroupState.opacity * curi.opacity),
             visible: (curGroupState.visible && curi.visible),
-            properties: ConvertProperties(curi.properties)
+            properties: Extend(ConvertProperties(curi.properties), curGroupState.properties)
+
         });
     }
 

--- a/src/tilemaps/parsers/tiled/ParseJSONTiled.js
+++ b/src/tilemaps/parsers/tiled/ParseJSONTiled.js
@@ -12,6 +12,7 @@ var ParseTilesets = require('./ParseTilesets');
 var ParseObjectLayers = require('./ParseObjectLayers');
 var BuildTilesetIndex = require('./BuildTilesetIndex');
 var AssignTileProperties = require('./AssignTileProperties');
+var ConvertProperties = require('./ConvertProperties');
 
 /**
  * Parses a Tiled JSON object into a new MapData object.
@@ -48,7 +49,7 @@ var ParseJSONTiled = function (name, json, insertNull)
         orientation: json.orientation,
         format: Formats.TILED_JSON,
         version: json.version,
-        properties: json.properties,
+        properties: ConvertProperties(json.properties),
         renderOrder: json.renderorder,
         infinite: json.infinite
     });

--- a/src/tilemaps/parsers/tiled/ParseObject.js
+++ b/src/tilemaps/parsers/tiled/ParseObject.js
@@ -6,6 +6,7 @@
 
 var Pick = require('../../../utils/object/Pick');
 var ParseGID = require('./ParseGID');
+var ConvertProperties = require('./ConvertProperties');
 
 var copyPoints = function (p) { return { x: p.x, y: p.y }; };
 
@@ -32,6 +33,11 @@ var ParseObject = function (tiledObject, offsetX, offsetY)
 
     parsedObject.x += offsetX;
     parsedObject.y += offsetY;
+
+    if (tiledObject.properties)
+    {
+        parsedObject.properties = ConvertProperties(tiledObject.properties);
+    }
 
     if (tiledObject.gid)
     {

--- a/src/tilemaps/parsers/tiled/ParseObjectLayers.js
+++ b/src/tilemaps/parsers/tiled/ParseObjectLayers.js
@@ -4,6 +4,7 @@
  * @license      {@link https://opensource.org/licenses/MIT|MIT License}
  */
 
+var Extend = require('../../../utils/object/Extend');
 var GetFastValue = require('../../../utils/object/GetFastValue');
 var ParseObject = require('./ParseObject');
 var ObjectLayer = require('../../mapdata/ObjectLayer');
@@ -74,7 +75,7 @@ var ParseObjectLayers = function (json)
         var offsetX = curGroupState.x + GetFastValue(curo, 'startx', 0) + GetFastValue(curo, 'offsetx', 0);
         var offsetY = curGroupState.y + GetFastValue(curo, 'starty', 0) + GetFastValue(curo, 'offsety', 0);
 
-        curo.properties = ConvertProperties(curo.properties);
+        curo.properties = Extend(ConvertProperties(curo.properties), curGroupState.properties);
 
         var objects = [];
         for (var j = 0; j < curo.objects.length; j++)

--- a/src/tilemaps/parsers/tiled/ParseObjectLayers.js
+++ b/src/tilemaps/parsers/tiled/ParseObjectLayers.js
@@ -8,6 +8,7 @@ var GetFastValue = require('../../../utils/object/GetFastValue');
 var ParseObject = require('./ParseObject');
 var ObjectLayer = require('../../mapdata/ObjectLayer');
 var CreateGroupLayer = require('./CreateGroupLayer');
+var ConvertProperties = require('./ConvertProperties');
 
 /**
  * Parses a Tiled JSON object into an array of ObjectLayer objects.
@@ -72,6 +73,8 @@ var ParseObjectLayers = function (json)
         curo.name = curGroupState.name + curo.name;
         var offsetX = curGroupState.x + GetFastValue(curo, 'startx', 0) + GetFastValue(curo, 'offsetx', 0);
         var offsetY = curGroupState.y + GetFastValue(curo, 'starty', 0) + GetFastValue(curo, 'offsety', 0);
+
+        curo.properties = ConvertProperties(curo.properties);
 
         var objects = [];
         for (var j = 0; j < curo.objects.length; j++)

--- a/src/tilemaps/parsers/tiled/ParseTileLayers.js
+++ b/src/tilemaps/parsers/tiled/ParseTileLayers.js
@@ -10,6 +10,7 @@ var LayerData = require('../../mapdata/LayerData');
 var ParseGID = require('./ParseGID');
 var Tile = require('../../Tile');
 var CreateGroupLayer = require('./CreateGroupLayer');
+var ConvertProperties = require('./ConvertProperties');
 
 /**
  * Parses all tilemap layers in a Tiled JSON object into new LayerData objects.
@@ -127,7 +128,7 @@ var ParseTileLayers = function (json, insertNull)
                 tileHeight: json.tileheight,
                 alpha: (curGroupState.opacity * curl.opacity),
                 visible: (curGroupState.visible && curl.visible),
-                properties: GetFastValue(curl, 'properties', [])
+                properties: ConvertProperties(curl.properties)
             });
 
             for (var c = 0; c < curl.height; c++)
@@ -200,7 +201,7 @@ var ParseTileLayers = function (json, insertNull)
                 tileHeight: json.tileheight,
                 alpha: (curGroupState.opacity * curl.opacity),
                 visible: (curGroupState.visible && curl.visible),
-                properties: GetFastValue(curl, 'properties', [])
+                properties: ConvertProperties(curl.properties)
             });
 
             var row = [];

--- a/src/tilemaps/parsers/tiled/ParseTileLayers.js
+++ b/src/tilemaps/parsers/tiled/ParseTileLayers.js
@@ -5,6 +5,7 @@
  */
 
 var Base64Decode = require('./Base64Decode');
+var Extend = require('../../../utils/object/Extend');
 var GetFastValue = require('../../../utils/object/GetFastValue');
 var LayerData = require('../../mapdata/LayerData');
 var ParseGID = require('./ParseGID');
@@ -128,7 +129,7 @@ var ParseTileLayers = function (json, insertNull)
                 tileHeight: json.tileheight,
                 alpha: (curGroupState.opacity * curl.opacity),
                 visible: (curGroupState.visible && curl.visible),
-                properties: ConvertProperties(curl.properties)
+                properties: Extend(ConvertProperties(curl.properties), curGroupState.properties)
             });
 
             for (var c = 0; c < curl.height; c++)
@@ -201,7 +202,7 @@ var ParseTileLayers = function (json, insertNull)
                 tileHeight: json.tileheight,
                 alpha: (curGroupState.opacity * curl.opacity),
                 visible: (curGroupState.visible && curl.visible),
-                properties: ConvertProperties(curl.properties)
+                properties: Extend(ConvertProperties(curl.properties), curGroupState.properties)
             });
 
             var row = [];

--- a/src/tilemaps/parsers/tiled/ParseTilesets.js
+++ b/src/tilemaps/parsers/tiled/ParseTilesets.js
@@ -7,6 +7,7 @@
 var Tileset = require('../../Tileset');
 var ImageCollection = require('../../ImageCollection');
 var ParseObject = require('./ParseObject');
+var ConvertProperties = require('./ConvertProperties');
 
 /**
  * Tilesets and Image Collections
@@ -54,14 +55,7 @@ var ParseTilesets = function (json)
                         //  Convert tileproperties
                         if (tile.properties)
                         {
-                            var newPropData = {};
-
-                            tile.properties.forEach(function (propData)
-                            {
-                                newPropData[propData['name']] = propData['value'];
-                            });
-
-                            props[tile.id] = newPropData;
+                            props[tile.id] = ConvertProperties(tile.properties);
                         }
 
                         //  Convert objectgroup


### PR DESCRIPTION
**This is a temporary "notes taking" PR which will be moved to the official phase repo when ready.**

## Feature
Parsing of tilemap group layers was added in [this PR](https://github.com/photonstorm/phaser/pull/4820) but group properties were left out.
In this PR, I add support for group properties. Since groups are discarded after parsing, I've chosen to make layers & objects inherit properties from their group ancestors.

While writing this code, I found several issues with the existing property handling code. That's the subject of the next section.

## Issues

Audit:
- `tileProperties` are converted to objects (code differentiates between Tiled versions)
https://github.com/floriancargoet/phaser/blob/d6e860076637c1686adcfcd64afd40c829b5d181/src/tilemaps/parsers/tiled/ParseTilesets.js#L55-L65
https://github.com/floriancargoet/phaser/blob/d6e860076637c1686adcfcd64afd40c829b5d181/src/tilemaps/parsers/tiled/ParseTilesets.js#L41-L43
- `properties` on tile layers & image layers are copied and not converted. The default values are inconsistent.
https://github.com/floriancargoet/phaser/blob/d6e860076637c1686adcfcd64afd40c829b5d181/src/tilemaps/parsers/tiled/ParseTileLayers.js#L130
https://github.com/floriancargoet/phaser/blob/d6e860076637c1686adcfcd64afd40c829b5d181/src/tilemaps/parsers/tiled/ParseImageLayers.js#L75
- `properties` on objects layers are ignored (not occurence of `properties` in [ParseObjectLayers.js](https://github.com/photonstorm/phaser/blob/master/src/tilemaps/parsers/tiled/ParseObjectLayers.js))
- `createFromObjects()` expects properties to be an object, not an array. The result is that instead of storing `{"name": "value" }` in `sprite.data`, it stores `{ "0" : { name: "name", value: "value", type: "type"}`. 
https://github.com/floriancargoet/phaser/blob/63eb41eb945bb3b557ec48bf93dd87d6c00cf0cb/src/tilemaps/Tilemap.js#L661
https://github.com/floriancargoet/phaser/blob/63eb41eb945bb3b557ec48bf93dd87d6c00cf0cb/src/tilemaps/Tilemap.js#L698-L706
- a [PR](https://github.com/photonstorm/phaser/pull/4984) shows an issue with [] vs {} but doesn't fix the inconsistencies ([original issue](https://github.com/photonstorm/phaser/issues/4983))

To do:
- [ ] Explain the proposed solution
- [ ] Replace the TypeScript type `properties?: any` to `properties?: {[string]: unknown}`
- [ ] Maybe split the fix & the new feature in 2 PRs
- [ ] Discuss this issue & the proposed solution with the Phaser team
- [ ] Investigate deprecated `propertyTypes` (not used in Phaser, [removed in Tiled 1.2](https://doc.mapeditor.org/en/latest/reference/json-map-format/#tiled-1-2))
- [ ] Tests
- [ ] Replace links to code before submitting the PR for correct code snippet integration

